### PR TITLE
Incorrect key/id pair being set

### DIFF
--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -79,7 +79,7 @@ func (b *Bitwarden) GetByKey(key string, orgID string) (string, error) {
 		}
 		found := false
 		for _, keyPair := range keyList.Data {
-			b.Cache.SetID(key, keyPair.ID)
+			b.Cache.SetID(keyPair.Key, keyPair.ID)
 			// To avoid running into throttling from Bitwarden only
 			// cache the secret value for what was asked for rather
 			// than caching every secret returned. The key/id mapping


### PR DESCRIPTION
Initially was using the key passed from the user and setting the ID iteratively found from BWS. Need to instead use the key/ID from them instead.