### PR TITLE
Cache entire json payload

### DIFF
--- a/internal/pkg/client/client.go
+++ b/internal/pkg/client/client.go
@@ -91,7 +91,8 @@ func (b *Bitwarden) GetByKey(key string, orgID string) (string, error) {
 				if err != nil {
 					return "", err
 				}
-				b.Cache.SetSecret(keyPair.ID, BwsSecret.Value)
+				storedSecret, _ := json.Marshal(BwsSecret)
+				b.Cache.SetSecret(keyPair.ID, string(storedSecret))
 			}
 		}
 		if !found {
@@ -107,8 +108,9 @@ func (b *Bitwarden) GetByKey(key string, orgID string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		b.Cache.SetSecret(id, BwsSecret.Value)
-		secret = BwsSecret.Value
+		storedSecret, _ := json.Marshal(BwsSecret)
+		b.Cache.SetSecret(id, string(storedSecret))
+		secret = string(storedSecret)
 	}
 	return secret, nil
 }


### PR DESCRIPTION
Python version stored the entire payload in the cache and the externalSecret's pulled the "Value" key out of the json paylod. I initially was just returning the value, which broke the secrets. Rather than force re-creating all of the external secrets store the payload for compatibility reasons.